### PR TITLE
fix: resolve z-index overlap on floating reminder card

### DIFF
--- a/www/app/components/HeroSection.tsx
+++ b/www/app/components/HeroSection.tsx
@@ -145,7 +145,7 @@ export function HeroSection() {
             <motion.div
               animate={{ y: [0, -10, 0] }}
               transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
-              className="absolute top-10 -end-4 z-50 bg-white dark:bg-gray-900 rounded-2xl p-4 shadow-xl border border-gray-100 dark:border-gray-800"
+              className="absolute top-10 -end-4 z-20 bg-white dark:bg-gray-900 rounded-2xl p-4 shadow-xl border border-gray-100 dark:border-gray-800"
             >
               <div className="flex items-center gap-3">
                 <div className="w-10 h-10 bg-emerald-100 dark:bg-emerald-900/30 rounded-full flex items-center justify-center">


### PR DESCRIPTION
## Summary
- Fix the floating reminder notification card in HeroSection overlapping the navigation bar and adjacent content
- The card had `z-50` (same as the nav), causing incorrect stacking. Lowered to `z-20` to maintain proper layer order

Fixes #36