### PR TITLE
fix: ensure theme colors update when toggling light/dark mode

### DIFF
--- a/core/js/theme.js
+++ b/core/js/theme.js
@@ -47,18 +47,20 @@ export const themeManager = {
     applyTheme(theme) {
         const root = document.documentElement;
         const body = document.body;
-        
+
         if (theme === 'dark') {
             root.classList.add(DARK_CLASS);
             if (body) body.classList.add(DARK_CLASS);
-            console.log('Dark theme applied');
         } else {
             root.classList.remove(DARK_CLASS);
             if (body) body.classList.remove(DARK_CLASS);
-            console.log('Light theme applied');
         }
 
-        // Update native status bar style on Capacitor
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) {
+            meta.setAttribute('content', theme === 'dark' ? '#065f46' : '#10b981');
+        }
+
         this._updateSystemBars(theme);
     },
 

--- a/www/app/components/HeroSection.tsx
+++ b/www/app/components/HeroSection.tsx
@@ -29,9 +29,9 @@ export function HeroSection() {
             transition={{ duration: 0.8, delay: 0.2 }}
             className="text-center lg:text-start"
           >
-            <div className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-100/50 rounded-full mb-6">
+            <div className="inline-flex items-center gap-2 px-4 py-2 bg-emerald-100/50 dark:bg-emerald-900/30 rounded-full mb-6">
               <span className="w-2 h-2 bg-emerald-500 rounded-full animate-pulse"></span>
-              <span className="text-sm text-emerald-700 dark:text-white font-medium">{t('hero.badge')}</span>
+              <span className="text-sm text-emerald-700 dark:text-emerald-300 font-medium">{t('hero.badge')}</span>
             </div>
             
             <h1 className="text-5xl lg:text-6xl font-bold text-gray-900 dark:text-white mb-6 leading-tight">
@@ -79,7 +79,7 @@ export function HeroSection() {
               </div>
             </div>
             
-            <div className="mt-10 flex items-center gap-8 text-sm text-gray-500 justify-center lg:justify-start">
+            <div className="mt-10 flex items-center gap-8 text-sm text-gray-500 dark:text-gray-400 justify-center lg:justify-start">
               <div className="flex items-center gap-2 font-medium">
                 <svg className="w-5 h-5 text-emerald-500" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />

--- a/www/app/components/ThemeToggle.tsx
+++ b/www/app/components/ThemeToggle.tsx
@@ -3,6 +3,18 @@ import { Sun, Moon } from 'lucide-react';
 import { Button } from './ui/button';
 import { motion, AnimatePresence } from 'framer-motion';
 
+const THEME_COLORS = {
+  light: '#10b981',
+  dark: '#065f46',
+};
+
+function updateMetaThemeColor(theme: 'light' | 'dark') {
+  const meta = document.querySelector('meta[name="theme-color"]');
+  if (meta) {
+    meta.setAttribute('content', THEME_COLORS[theme]);
+  }
+}
+
 export function ThemeToggle() {
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     if (typeof window !== 'undefined') {
@@ -17,11 +29,11 @@ export function ThemeToggle() {
     const root = window.document.documentElement;
     if (theme === 'dark') {
       root.classList.add('dark');
-      localStorage.setItem('theme', 'dark');
     } else {
       root.classList.remove('dark');
-      localStorage.setItem('theme', 'light');
     }
+    localStorage.setItem('theme', theme);
+    updateMetaThemeColor(theme);
   }, [theme]);
 
   const toggleTheme = () => {

--- a/www/core/js/theme.js
+++ b/www/core/js/theme.js
@@ -47,18 +47,20 @@ export const themeManager = {
     applyTheme(theme) {
         const root = document.documentElement;
         const body = document.body;
-        
+
         if (theme === 'dark') {
             root.classList.add(DARK_CLASS);
             if (body) body.classList.add(DARK_CLASS);
-            console.log('Dark theme applied');
         } else {
             root.classList.remove(DARK_CLASS);
             if (body) body.classList.remove(DARK_CLASS);
-            console.log('Light theme applied');
         }
 
-        // Update native status bar style on Capacitor
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) {
+            meta.setAttribute('content', theme === 'dark' ? '#065f46' : '#10b981');
+        }
+
         this._updateSystemBars(theme);
     },
 

--- a/www/index.html
+++ b/www/index.html
@@ -27,8 +27,13 @@
     <script>
       (function() {
         var theme = localStorage.getItem('theme');
-        if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        var isDark = theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (isDark) {
           document.documentElement.classList.add('dark');
+        }
+        var meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) {
+          meta.setAttribute('content', isDark ? '#065f46' : '#10b981');
         }
       })();
     </script>

--- a/www/styles/theme.css
+++ b/www/styles/theme.css
@@ -128,9 +128,18 @@
     @apply border-border outline-ring/50;
   }
 
+  html {
+    color-scheme: light;
+  }
+
+  html.dark {
+    color-scheme: dark;
+  }
+
   body {
     @apply bg-background text-foreground;
     font-family: 'Tajawal', 'Amiri', sans-serif;
+    transition: background-color 0.3s ease, color 0.3s ease;
   }
 
   /* Hide scrollbar for screenshots carousel */


### PR DESCRIPTION
## Summary
- Add `color-scheme` CSS property to `<html>` for proper browser dark mode rendering hints
- Add smooth `transition` on body `background-color` and `color` for a polished theme switch experience
- Fix missing `dark:` variants on HeroSection badge (`bg-emerald-100/50`) and stat text (`text-gray-500`)
- Dynamically update `<meta name="theme-color">` when the theme changes (both website ThemeToggle and core themeManager)
- Enhance FOUC prevention script to also set the correct `meta theme-color` on initial load

## Test plan
- [ ] Toggle theme on the website landing page and verify background, text, and UI colors all change
- [ ] Verify the "Available on all platforms" badge adapts to dark mode
- [ ] Verify the feature stat text (Free Forever, No Ads, Open Source) is visible in dark mode
- [ ] Verify `meta theme-color` updates when toggling (inspect in DevTools)
- [ ] Verify theme persists after page reload
- [ ] Verify no FOUC when loading with a saved dark theme
- [ ] Verify smooth color transition when switching themes

Closes #34